### PR TITLE
tech: load lexend font and use it on body

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,0 +1,13 @@
+--- 
+--- 
+
+@charset "utf-8";
+
+@import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}"; // skin
+@import "minimal-mistakes"; // main partials
+
+@import url('https://fonts.googleapis.com/css?family=Lexend&display=swap');
+
+body {
+  font-family: 'Lexend';
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,5 +1,8 @@
 ---
 ---
+@import "/assets/css/main.css";
+
+
 $lg-image-height: 500px;
 $sm-image-height: 100px;
 


### PR DESCRIPTION
Change the default font for posts to [lexend](https://www.lexend.com/). This was done by overwriting the `main.scss` file used by minimal mistakes/jekyll with a custom one.